### PR TITLE
고친듯 고치지 않은..

### DIFF
--- a/js/hotel/hotel-booking-template.js
+++ b/js/hotel/hotel-booking-template.js
@@ -211,10 +211,6 @@ export function getBookingPanelHTML() {
                 <button type="submit" form="bookingForm" class="btn-submit" id="submitBtn">
                   결제하기
                 </button>
-
-                <button type="button" class="btn-schedule" id="scheduleBtn">
-                  일정에 담기
-                </button>
               </div>
             </div>
 

--- a/js/hotel/hotel-booking.js
+++ b/js/hotel/hotel-booking.js
@@ -222,79 +222,8 @@ export function initBookingPanel(root, bookingData, { onClose } = {}) {
     });
   });
 
-  function validateForm() {
-    let isValid = true;
-
-    const checkIn = checkInInput;
-    const checkOut = checkOutInput;
-
-    if (!checkIn.value) {
-      checkIn.closest(".form-group")?.classList.add("error");
-      isValid = false;
-    } else {
-      checkIn.closest(".form-group")?.classList.remove("error");
-    }
-
-    if (!checkOut.value) {
-      checkOut.closest(".form-group")?.classList.add("error");
-      isValid = false;
-    } else {
-      checkOut.closest(".form-group")?.classList.remove("error");
-    }
-
-    if (checkIn.value && checkOut.value) {
-      const nights = getNights(checkIn.value, checkOut.value);
-      if (nights <= 0) {
-        alert("체크아웃 날짜는 체크인 날짜 이후여야 합니다.");
-        isValid = false;
-      }
-    }
-
-    const guestName = root.querySelector("#guestName");
-    const guestNameEn = root.querySelector("#guestNameEn");
-    const phone = root.querySelector("#phone");
-    const email = root.querySelector("#email");
-
-    if (!guestName?.value.trim()) {
-      guestName?.closest(".form-group")?.classList.add("error");
-      isValid = false;
-    } else {
-      guestName.closest(".form-group")?.classList.remove("error");
-    }
-
-    if (!guestNameEn?.value.trim()) {
-      guestNameEn?.closest(".form-group")?.classList.add("error");
-      isValid = false;
-    } else {
-      guestNameEn.closest(".form-group")?.classList.remove("error");
-    }
-
-    if (!phone?.value.trim()) {
-      phone?.closest(".form-group")?.classList.add("error");
-      isValid = false;
-    } else {
-      phone.closest(".form-group")?.classList.remove("error");
-    }
-
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!email?.value.trim() || !emailRegex.test(email.value)) {
-      email?.closest(".form-group")?.classList.add("error");
-      isValid = false;
-    } else {
-      email.closest(".form-group")?.classList.remove("error");
-    }
-
-    if (!agreeTerms?.checked || !agreePrivacy?.checked) {
-      alert("필수 약관에 동의해주세요.");
-      isValid = false;
-    }
-
-    return isValid;
-  }
-
   bookingForm.addEventListener("submit", async (e) => {
     e.preventDefault();
-    if (!validateForm()) return;
 
     const checkIn = new Date(checkInInput.value);
     const checkOut = new Date(checkOutInput.value);


### PR DESCRIPTION
챗지피티 렉걸려서, gemini 붙잡고 물어보니까 JS 기본 HTML validation UI(submit 이벤트 등에서 발동)라는게 있다고 하더라고요.
어쩐지 코드에서 찾아볼수조차 없는 안내창이 친절하게 해당 위치로 이동까지 한다 하더라니...
다른 입력 폼이 다 그걸로 너무 편한데, 이메일 하나때문에 전부 alert로 바꾸기도 애매하고,
이메일 하나만 alert 하는것도 이상하고,
그래서 기본 HTML validation UI를 이메일에 써보려고 HTML에 pattern=(정규식) 해보고, gemini가 시키는대로 해봤는데도 잘 안돼요.

커스텀 validation이 기본 HTML validation UI랑 충돌하는 것 같아서, 그냥 커스텀 validation 빼버리고, a@a같은 이메일은 통과시키는 쪽으로 했습니다.. (생각해보니 전화번호도 이미 텍스트 다 들어가던데)

근찬님 피드백 너무 감사하지만, 제 능력 부족은 어쩔수가 없나봐요ㅠ
제가 생각해보니 이메일 붙잡고 있을 때가 아니라, 사용자 중복 예약(겹치는 예약) 차단을 해야 할 것 같다는 생각이 들어서요..

로컬 브랜치가 처참히 망가져서 기존 pr 닫고 새로 올려요
