### PR TITLE
bugfix: dup checking error

### DIFF
--- a/js/hotel/hotel-booking.js
+++ b/js/hotel/hotel-booking.js
@@ -125,6 +125,7 @@ export function initBookingPanel(root, bookingData, userReservationInfo, { onClo
   const agreePrivacy = root.querySelector("#agreePrivacy");
 
   const hasIntersection = (oldRes, newRes) => {
+    //console.log(oldRes.checkIn,oldRes.checkOut,newRes.checkIn,newRes.checkOut); //확인용
     if(oldRes.checkOut <= newRes.checkIn || newRes.checkOut <= oldRes.checkIn) return false;
     return true;
   };
@@ -225,7 +226,10 @@ export function initBookingPanel(root, bookingData, userReservationInfo, { onClo
 
     const checkIn = new Date(checkInInput.value);
     const checkOut = new Date(checkOutInput.value);
-    const newReservation = {checkIn, checkOut};
+    const newReservation = {
+      checkIn: new Date(new Date(checkInInput.value).setHours(0, 0, 0, 0)),
+      checkOut: new Date(new Date(checkOutInput.value).setHours(0, 0, 0, 0)),
+    };
     const roomType = roomTypeSelect.value;
     const nights = getNights(checkIn, checkOut);
     


### PR DESCRIPTION
newReservation의 shallow copy로 인한 날짜 비교 로직 버그 (신규 예약 체크아웃=기존 예약 체크인일때, 중복에 걸려버림)
deep copy로 수정